### PR TITLE
Update Lodash to 4.17.15 to resolve NPM audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bluebird": "^2.9.1",
     "chalk": "^0.5.1",
-    "lodash": "^2.4.1",
+    "lodash": "^4.17.15",
     "mkdirp": "^0.5.0",
     "path2": "^0.1.0",
     "shipit-utils": "^1.0.1",


### PR DESCRIPTION
The selected version of Lodash is outdated and there are a number of security warnings for it.

The only two methods used are `_.assign` and `_.defaults` which both work the same from v2 to v4.